### PR TITLE
fix: using requests package

### DIFF
--- a/github-ip-lambda-function.py
+++ b/github-ip-lambda-function.py
@@ -1,6 +1,6 @@
 import os
 import boto3
-from botocore.vendored import requests
+import requests
 
 
 def get_cloudflare_ip_list():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,11 @@
-boto3
-botocore
+boto3==1.15.5
+botocore==1.18.5
+certifi==2020.6.20
+chardet==3.0.4
+idna==2.10
+jmespath==0.10.0
+python-dateutil==2.8.1
+requests==2.24.0
+s3transfer==0.3.3
+six==1.15.0
+urllib3==1.25.10


### PR DESCRIPTION
Hi,

A PR to prevent warning message during execution of lambda.

> /var/runtime/botocore/vendored/requests/api.py:72:  \
DeprecationWarning: You are using the get() function from 'botocore.vendored.requests'.   \
This dependency was removed from Botocore and will be removed from Lambda after 2021/01/30.  \
https://aws.amazon.com/blogs/developer/removing-the-vendored-version-of-requests-from-botocore/.  \
Install the requests package, 'import requests' directly, and use the requests.get() function instead.